### PR TITLE
Fixed chef version (provision with chef 14 fails)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,7 @@ Vagrant.configure(2) do |config|
 
     node.vm.provision 'chef_solo' do |chef|
       chef.cookbooks_path = ['chef/berks-cookbooks', 'chef/cookbooks']
+      chef.version = '13.8.5'
       chef.json = {
         'apprenda_linux' => {
           'hostname' => 'apprlin',


### PR DESCRIPTION
Provisioning with the latest version of chef solo fails. Using chef 13 fixes it. 

==> apprenda-linux: ------------
==> apprenda-linux:     
==> apprenda-linux: chef_version=14.0.190
==> apprenda-linux:     
==> apprenda-linux: platform=centos
==> apprenda-linux:     platform_version=7.3.1611
==> apprenda-linux:     ruby=ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
==> apprenda-linux:     program_name=/bin/chef-solo
==> apprenda-linux:     
==> apprenda-linux: executable=/opt/chef/bin/chef-solo
==> apprenda-linux:     
==> apprenda-linux: 
==> apprenda-linux: [2018-04-13T14:39:26+00:00] INFO: Running queued delayed notifications before re-raising exception
==> apprenda-linux: [2018-04-13T14:39:26+00:00] INFO: Running queued delayed notifications before re-raising exception
==> apprenda-linux: 
==> apprenda-linux: Running handlers:
==> apprenda-linux: [2018-04-13T14:39:26+00:00] ERROR: Running exception handlers
==> apprenda-linux: [2018-04-13T14:39:26+00:00] ERROR: Running exception handlers
==> apprenda-linux: Running handlers complete
==> apprenda-linux: [2018-04-13T14:39:26+00:00] ERROR: Exception handlers complete
==> apprenda-linux: [2018-04-13T14:39:26+00:00] ERROR: Exception handlers complete
==> apprenda-linux: Chef Client failed. 1 resources updated in 24 seconds
==> apprenda-linux: [2018-04-13T14:39:26+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> apprenda-linux: [2018-04-13T14:39:26+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> apprenda-linux: [2018-04-13T14:39:26+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
==> apprenda-linux: [2018-04-13T14:39:26+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
==> apprenda-linux: [2018-04-13T14:39:26+00:00] FATAL: NameError: docker_service[default] (apprenda_linux::docker line 1) had an error: NameError: undefined local variable or method `install_method' for #<#<Class:0x0000000005846728>:0x000000000461e0a0>
==> apprenda-linux: [2018-04-13T14:39:26+00:00] FATAL: NameError: docker_service[default] (apprenda_linux::docker line 1) had an error: NameError: undefined local variable or method `install_method' for #<#<Class:0x0000000005846728>:0x000000000461e0a0>